### PR TITLE
hack for other compatible fp sensors

### DIFF
--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -62,12 +62,17 @@ _REGMODEL = const(0x05)
 _STORE = const(0x06)
 _LOAD = const(0x07)
 _UPLOAD = const(0x08)
+_DOWNLOAD = const(0x09)
+_UPLOADIMAGE = const(0x0A)
+_DOWNLOADIMAGE = const(0x0B)
 _DELETE = const(0x0C)
 _EMPTY = const(0x0D)
+_READSYSPARA = const(0x0F)
 _HISPEEDSEARCH = const(0x1B)
 _VERIFYPASSWORD = const(0x13)
 _TEMPLATECOUNT = const(0x1D)
 _TEMPLATEREAD = const(0x1F)
+_GETECHO = const(0x53)
 
 # Packet error code
 OK = const(0x0)
@@ -92,6 +97,7 @@ FLASHERR = const(0x18)
 INVALIDREG = const(0x1A)
 ADDRCODE = const(0x20)
 PASSVERIFY = const(0x21)
+MODULEOK = const(0x55)
 
 class Adafruit_Fingerprint:
     """UART based fingerprint sensor."""
@@ -103,6 +109,11 @@ class Adafruit_Fingerprint:
     confidence = None
     templates = []
     template_count = None
+    library_size = None
+    security_level = None
+    device_address = None
+    data_packet_size = None
+    baudrate = None
 
     def __init__(self, uart, passwd=(0, 0, 0, 0)):
 	# Create object with UART for interface, and default 32-bit password
@@ -110,6 +121,14 @@ class Adafruit_Fingerprint:
         self._uart = uart
         if self.verify_password() != OK:
             raise RuntimeError('Failed to find sensor, check wiring!')
+
+    def check_module(self):
+        """Checks the state of the fingerprint scanner module.
+        Returns OK or error."""
+        self._send_packet([_GETECHO])
+        if self._get_packet(12)[0] != MODULEOK:
+            raise RuntimeError('Something is wrong with the sensor.')
+        return True
 
     def verify_password(self):
         """Checks if the password/connection is correct, returns True/False"""
@@ -122,6 +141,19 @@ class Adafruit_Fingerprint:
         self._send_packet([_TEMPLATECOUNT])
         r = self._get_packet(14)
         self.template_count = struct.unpack('>H', bytes(r[1:3]))[0]
+        return r[0]
+
+    def read_sysparam(self):
+        """Returns the system parameters on success via attributes."""
+        self._send_packet([_READSYSPARA])
+        r = self._get_packet(28)
+        if r[0] != OK:
+            raise RuntimeError('Command failed.')
+        self.library_size = struct.unpack('>H', bytes(r[5:7]))[0]
+        self.security_level = struct.unpack('>H', bytes(r[7:9]))[0]
+        self.device_address = bytes(r[9:13])
+        self.data_packet_size = struct.unpack('>H', bytes(r[13:15]))[0]
+        self.baudrate = struct.unpack('>H', bytes(r[15:17]))[0]
         return r[0]
 
     def get_image(self):
@@ -142,10 +174,10 @@ class Adafruit_Fingerprint:
         self._send_packet([_REGMODEL])
         return self._get_packet(12)[0]
 
-    def store_model(self, location):
+    def store_model(self, location, charbuf):
         """Requests the sensor store the model into flash memory and assign
         a location. Returns the packet error code or OK success"""
-        self._send_packet([_STORE, 1, location >> 8, location & 0xFF])
+        self._send_packet([_STORE, charbuf, location >> 8, location & 0xFF])
         return self._get_packet(12)[0]
 
     def delete_model(self, location):
@@ -153,6 +185,48 @@ class Adafruit_Fingerprint:
         the argument location. Returns the packet error code or OK success"""
         self._send_packet([_DELETE, location >> 8, location & 0xFF, 0x00, 0x01])
         return self._get_packet(12)[0]
+
+    def load_model(self, location, charbuf):
+        """
+        """
+        self._send_packet([_LOAD, charbuf, location >> 8, location & 0xFF])
+        return self._get_packet(12)[0]
+
+    def get_fpdata(self, buffer='char', slot=1):
+        """Requests the sensor to transfer the fingerprint image or
+        template.  Returns the data payload only."""
+        if slot != 1 or slot != 2:
+            # raise error or use default value?
+            slot = 1
+        if buffer == 'image':
+            self._send_packet([_UPLOADIMAGE])
+        elif buffer == 'char':
+            self._send_packet([_UPLOAD, slot])
+        else:
+            raise RuntimeError('Uknown buffer type')
+        if self._get_packet(12)[0] == 0:
+            res = self._get_data(9)
+            #print('datasize: ' + str(len(res)))
+        #print(res)
+        return res
+
+    def send_fpdata(self, data, buffer='char', slot=1):
+        """ONGOING"""
+        print(slot)
+        if slot != 1 or slot != 2:
+            # raise error or use default value?
+            slot = 2
+        if buffer == 'image':
+            self._send_packet([_DOWNLOADIMAGE])
+        elif buffer == 'char':
+            self._send_packet([_DOWNLOAD, slot])
+        else:
+            raise RuntimeError('Uknown buffer type')
+        if self._get_packet(12)[0] == 0:
+            self._send_data(data) 
+            #print('datasize: ' + str(len(res)))
+        #print(res)
+        return True
 
     def empty_library(self):
         """Requests the sensor to delete all models from flash memory.
@@ -164,8 +238,9 @@ class Adafruit_Fingerprint:
         """Requests the sensor to list of all template locations in use and
         stores them in self.templates. Returns the packet error code or OK success"""
         self.templates = []
+        self.read_sysparam()
         temp_r = [0x0c, ]
-        for j in range(4):
+        for j in range(int(self.library_size/250)):
             self._send_packet([_TEMPLATEREAD, j])
             r = self._get_packet(44)
             if r[0] == OK:
@@ -173,7 +248,7 @@ class Adafruit_Fingerprint:
                     byte = r[i+1]
                     for bit in range(8):
                         if byte & (1 << bit):
-                            self.templates.append(i * 8 + bit + j * 256)
+                            self.templates.append((i * 8) + bit + (j * 256))
                 temp_r = r
             else:
                 r = temp_r
@@ -185,7 +260,8 @@ class Adafruit_Fingerprint:
         and self.confidence. Returns the packet error code or OK success"""
         # high speed search of slot #1 starting at page 0x0000 and page #0x00A3
         #self._send_packet([_HISPEEDSEARCH, 0x01, 0x00, 0x00, 0x00, 0xA3])
-        self._send_packet([_HISPEEDSEARCH, 0x01, 0x00, 0x00, 0x03, 0xE8])
+        # or page #0x03E9 to accommodate modules with up to 1000 capacity
+        self._send_packet([_HISPEEDSEARCH, 0x01, 0x00, 0x00, 0x03, 0xE9])
         r = self._get_packet(16)
         self.finger_id, self.confidence = struct.unpack('>HH', bytes(r[1:5]))
         return r[0]
@@ -214,7 +290,58 @@ class Adafruit_Fingerprint:
         if packet_type != _ACKPACKET:
             raise RuntimeError('Incorrect packet data')
 
+        # we should check the checksum
+        # but i don't know how
+        # not yet anyway
+        #packet_sum = struct.unpack('>H', res[9+(length-2):9+length])[0]
+        #print(packet_sum)
+        #print(packet_type + length + struct.unpack('>HHHH', res[9:9+(length-2)]))
+
         reply = [i for i in res[9:9+(length-2)]]
+        #print(reply)
+        return reply
+
+    def _get_data(self, expected):
+        """ Gets packet from serial and checks structure for _DATAPACKET
+        and _ENDDATAPACKET.  Alternate method for getting data such
+        as fingerprint image, etc.  Returns the data payload."""
+        res = self._uart.read(expected)
+        #print("Got", res)
+        if (not res) or (len(res) != expected):
+            raise RuntimeError('Failed to read data from sensor')
+
+        # first two bytes are start code
+        start = struct.unpack('>H', res[0:2])[0]
+        #print(start)
+        if start != _STARTCODE:
+            raise RuntimeError('Incorrect packet data')
+        # next 4 bytes are address
+        addr = [i for i in res[2:6]]
+        #print(addr)
+        if addr != self.address:
+            raise RuntimeError('Incorrect address')
+
+        packet_type, length = struct.unpack('>BH', res[6:9])
+        #print(str(packet_type) + ' ' + str(length))
+
+        # todo: check checksum
+
+        if packet_type != _DATAPACKET:
+            if packet_type != _ENDDATAPACKET:
+                raise RuntimeError('Incorrect packet data')
+
+        if packet_type == _DATAPACKET:
+            res = self._uart.read(length-2)
+            # todo: we should really inspect the headers and checksum
+            reply = [i for i in res[0:length]]
+            self._uart.read(2) # disregard checksum but we really shouldn't
+            reply += self._get_data(9)
+        elif packet_type == _ENDDATAPACKET:
+            res = self._uart.read(length-2)
+            # todo: we should really inspect the headers and checksum
+            reply = [i for i in res[0:length]]
+            self._uart.read(2) # disregard checksum but we really shouldn't
+        print(len(reply))
         #print(reply)
         return reply
 
@@ -235,3 +362,74 @@ class Adafruit_Fingerprint:
 
         #print("Sending: ", [hex(i) for i in packet])
         self._uart.write(bytearray(packet))
+
+    def _send_data(self, data):
+        """ONGOING"""
+        print(len(data))
+        self.read_sysparam()
+        if self.data_packet_size == 0:
+            data_length = 32
+        elif self.data_packet_size == 1:
+            data_length = 64
+        elif self.data_packet_size == 2:
+            data_length = 128
+        elif self.data_packet_size == 3:
+            data_length = 256
+
+        for i in range(int(len(data) / (data_length - 2))):
+            start = i * (data_length - 2)
+            end = (i + 1) * (data_length - 2)
+            #print(start)
+            #print(end)
+            #print(i)
+
+            packet = [_STARTCODE >> 8, _STARTCODE & 0xFF]
+            packet = packet + self.address
+            packet.append(_DATAPACKET)
+            length = len(data[start:end]) + 2
+            #print(length)
+            packet.append(length >> 8)
+            packet.append(length & 0xFF)
+            checksum = _DATAPACKET + (length >> 8) + (length & 0xFF)
+
+            for j in range(len(data[start:end])):
+                packet.append(data[j])
+                #packet.append(struct.pack('@B', data[j]))
+                checksum += data[j]
+
+            packet.append(checksum >> 8)
+            packet.append(checksum & 0xFF)
+
+            #print("Sending: ", [hex(i) for i in packet])
+            #self._uart.write(bytearray(packet))
+            self._uart.write(packet)
+            #print(i)
+
+        i += 1
+        start = i * (data_length - 2)
+        end = (i + 1) * (data_length - 2)
+        #print(start)
+        #print(end)
+        #print(i)
+
+        packet = [_STARTCODE >> 8, _STARTCODE & 0xFF]
+        packet = packet + self.address
+        packet.append(_ENDDATAPACKET)
+        length = len(data[start:end]) + 2
+        #print(length)
+        packet.append(length >> 8)
+        packet.append(length & 0xFF)
+        checksum = _DATAPACKET + (length >> 8) + (length & 0xFF)
+
+        for j in range(len(data[start:end])):
+            packet.append(data[j])
+            #packet.append(struct.pack('@B', data[j]))
+            checksum += data[j]
+
+        packet.append(checksum >> 8)
+        packet.append(checksum & 0xFF)
+
+        #print("Sending: ", [hex(i) for i in packet])
+        #self._uart.write(bytearray(packet))
+        self._uart.write(packet)
+        #print(i)

--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -158,7 +158,7 @@ class Adafruit_Fingerprint:
         """Requests the sensor to list of all template locations in use and
         stores them in self.templates. Returns the packet error code or OK success"""
         self.templates = []
-        r1 = [ 0x0c, ]
+        temp_r = [0x0c, ]
         for j in range(4):
             self._send_packet([_TEMPLATEREAD, j])
             r = self._get_packet(44)
@@ -168,9 +168,9 @@ class Adafruit_Fingerprint:
                     for bit in range(8):
                         if byte & (1 << bit):
                             self.templates.append(i * 8 + bit + j * 256)
-                r1 = r
+                temp_r = r
             else:
-                r = r1
+                r = temp_r
         return r[0]
 
     def finger_fast_search(self):

--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -159,7 +159,6 @@ class Adafruit_Fingerprint:
         Returns the packet error code or OK success"""
         self._send_packet([_EMPTY])
         return self._get_packet(12)[0]
-        
 
     def read_templates(self):
         """Requests the sensor to list of all template locations in use and

--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -154,6 +154,13 @@ class Adafruit_Fingerprint:
         self._send_packet([_DELETE, location >> 8, location & 0xFF, 0x00, 0x01])
         return self._get_packet(12)[0]
 
+    def empty_library(self):
+        """Requests the sensor to delete all models from flash memory.
+        Returns the packet error code or OK success"""
+        self._send_packet([_EMPTY])
+        return self._get_packet(12)[0]
+        
+
     def read_templates(self):
         """Requests the sensor to list of all template locations in use and
         stores them in self.templates. Returns the packet error code or OK success"""

--- a/examples/fingerprint_simpletest.py
+++ b/examples/fingerprint_simpletest.py
@@ -1,6 +1,6 @@
 import time
 import board
-import busio
+#import busio
 from digitalio import DigitalInOut, Direction
 import adafruit_fingerprint
 
@@ -10,7 +10,7 @@ led.direction = Direction.OUTPUT
 #uart = busio.UART(board.TX, board.RX, baudrate=57600)
 
 # If using with a computer such as Linux/RaspberryPi, Mac, Windows...
-#import serial
+import serial
 #uart = serial.Serial("/dev/ttyUSB0", baudrate=57600, timeout=1)
 uart = serial.Serial("/dev/ttyAMA0", baudrate=57600, timeout=1)
 
@@ -194,8 +194,7 @@ while True:
         else:
             print("Failed to delete")
     if c == 'r':
-        finger._send_packet([adafruit_fingerprint._EMPTY])
-        if finger._get_packet(12)[0] == adafruit_fingerprint.OK:
+        if finger.empty_library() == adafruit_fingerprint.OK:
             print("Library empty!")
         else:
             print("Failed to empty library")

--- a/examples/fingerprint_simpletest.py
+++ b/examples/fingerprint_simpletest.py
@@ -1,6 +1,7 @@
 import time
 import board
 #import busio
+import serial
 from digitalio import DigitalInOut, Direction
 import adafruit_fingerprint
 
@@ -10,7 +11,7 @@ led.direction = Direction.OUTPUT
 #uart = busio.UART(board.TX, board.RX, baudrate=57600)
 
 # If using with a computer such as Linux/RaspberryPi, Mac, Windows...
-import serial
+#import serial
 #uart = serial.Serial("/dev/ttyUSB0", baudrate=57600, timeout=1)
 uart = serial.Serial("/dev/ttyAMA0", baudrate=57600, timeout=1)
 

--- a/examples/fingerprint_simpletest.py
+++ b/examples/fingerprint_simpletest.py
@@ -7,11 +7,12 @@ import adafruit_fingerprint
 led = DigitalInOut(board.D13)
 led.direction = Direction.OUTPUT
 
-uart = busio.UART(board.TX, board.RX, baudrate=57600)
+#uart = busio.UART(board.TX, board.RX, baudrate=57600)
 
 # If using with a computer such as Linux/RaspberryPi, Mac, Windows...
 #import serial
 #uart = serial.Serial("/dev/ttyUSB0", baudrate=57600, timeout=1)
+uart = serial.Serial("/dev/ttyAMA0", baudrate=57600, timeout=1)
 
 finger = adafruit_fingerprint.Adafruit_Fingerprint(uart)
 
@@ -152,10 +153,13 @@ def enroll_finger(location):
 
 def get_num():
     """Use input() to get a valid number from 1 to 127. Retry till success!"""
-    i = 0
-    while (i > 127) or (i < 1):
+    #i = 0
+    i = -1
+    #while (i > 127) or (i < 1):
+    while (i > 999) or (i < 0):
         try:
-            i = int(input("Enter ID # from 1-127: "))
+            #i = int(input("Enter ID # from 1-127: "))
+            i = int(input("Enter ID # from 0-999: "))
         except ValueError:
             pass
     return i
@@ -166,9 +170,14 @@ while True:
     if finger.read_templates() != adafruit_fingerprint.OK:
         raise RuntimeError('Failed to read templates')
     print("Fingerprint templates:", finger.templates)
+    if finger.count_templates() != adafruit_fingerprint.OK:
+        raise RuntimeError('Failed to read templates')
+    print("Number of templates: ", finger.template_count)
+    print("e) enroll print")
     print("e) enroll print")
     print("f) find print")
     print("d) delete print")
+    print("r) reset library")
     print("----------------")
     c = input("> ")
 
@@ -184,3 +193,9 @@ while True:
             print("Deleted!")
         else:
             print("Failed to delete")
+    if c == 'r':
+        finger._send_packet([adafruit_fingerprint._EMPTY])
+        if finger._get_packet(12)[0] == adafruit_fingerprint.OK:
+            print("Library empty!")
+        else:
+            print("Failed to empty library")

--- a/examples/fingerprint_simpletest.py
+++ b/examples/fingerprint_simpletest.py
@@ -1,9 +1,9 @@
 import time
 import board
 #import busio
-import serial
 from digitalio import DigitalInOut, Direction
 import adafruit_fingerprint
+import serial
 
 led = DigitalInOut(board.D13)
 led.direction = Direction.OUTPUT


### PR DESCRIPTION
dirty hack for compatible fingerprint sensors with capacity greater than the default, since the function limits reading the templates to 162(?).  an observation: each pass reads 256 templates (0-255) so for sensors with 1000 templates, 4 passes are required.  but there must be a better way to do this.  tested on this hardware: https://circuit-help.com.ph/product/fingerprint-sensor-2/